### PR TITLE
feat: caller ast modifier

### DIFF
--- a/fixtures/modifier/.serpackrc.ts
+++ b/fixtures/modifier/.serpackrc.ts
@@ -1,0 +1,16 @@
+export default <import('serpack').Options>{
+  compilerOptions: {
+    banner: "const __log=(...args)=>console.log(args.join(''));",
+    modifier: {
+      caller(node) {
+        const wrapCallExpression = {
+          type: 'CallExpression',
+          callee: { type: 'Identifier', name: '__log' },
+          arguments: [node],
+        };
+
+        return wrapCallExpression as any;
+      },
+    },
+  },
+};

--- a/fixtures/modifier/README.txt
+++ b/fixtures/modifier/README.txt
@@ -1,0 +1,8 @@
+Test Modifier
+
+$ node ./packages/serpack/dist/cli.js ./fixtures/modifier/index.ts  --cwd=./fixtures/modifier/ --output=./fixtures/modifier/a.js
+
+## Expected output
+
+hello
+hello2

--- a/fixtures/modifier/a.js
+++ b/fixtures/modifier/a.js
@@ -1,0 +1,34 @@
+const __log = (...args) => console.log(args.join(''));
+(function (modules) {
+  var __serpack_module_cache__ = {};
+  function __serpack_require__(id) {
+    if (!id.startsWith('sp:')) return require(id);
+    if (__serpack_module_cache__[id.slice(3)])
+      return __serpack_module_cache__[id.slice(3)];
+    const module = { exports: {} };
+    __serpack_module_cache__[id.slice(3)] = '__serpack_module_pending__';
+    modules[id.slice(3)].call(
+      module.exports,
+      __serpack_require__,
+      require,
+      module,
+      module.exports
+    );
+    __serpack_module_cache__[id.slice(3)] = module.exports;
+    return module.exports;
+  }
+  module.exports = __serpack_require__('sp:0');
+})({
+  /* D:\serpack\fixtures\modifier\index.ts */ 0: function (
+    __serpack_require__,
+    __non_serpack_require__,
+    module,
+    exports
+  ) {
+    'use strict';
+    function e(...l) {
+      return l;
+    }
+    __log(e('hello')), __log(e('hello2'));
+  },
+});

--- a/fixtures/modifier/index.ts
+++ b/fixtures/modifier/index.ts
@@ -1,0 +1,6 @@
+function hello(...args: any) {
+  return args;
+}
+
+hello(`${'hello'}`);
+hello(`${'hello2'}`);


### PR DESCRIPTION
a option that can modify ast (caller).

## Example
+  input
```ts
// entry.ts
function hello(...args: any) {
  return args;
}

hello(`${'hello'}`);
hello(`${'hello2'}`);

```
```ts
// .serpackrc.ts
export default <import('serpack').Options>{
  compilerOptions: {
    banner: 'const __log=(...args)=>console.log("message: " + args.join(\'\'));',
    modifier: {
      caller(node) {
        const wrapCallExpression = {
          type: 'CallExpression',
          callee: { type: 'Identifier', name: '__log' },
          arguments: [node],
        };

        return wrapCallExpression as any;
      },
    },
  },
};

```

+ output

```
message: hello
message: hello2
```