### PR TITLE
feat: change compiler to esbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # serpack
 
-Serpack is a JavaScript/TypeScript tool for application development, powered by [swc](https://swc.rs/).
+Serpack is a JavaScript/TypeScript tool for application development, powered by [esbuild](https://esbuild.github.io/).
 
 ```bash
 $ npx serpack ./src/awesome-app.ts # run script
 ```
 
-Serpack is optimized for high-speed bundling and execution of TypeScript files, leveraging [swc](https://swc.rs/) as a transformer and [oxc](https://oxc.rs/) as a resolver for enhanced performance.
+Serpack is optimized for high-speed bundling and execution of TypeScript files, leveraging [esbuild](https://esbuild.github.io/) as a transformer and [oxc](https://oxc.rs/) as a resolver for enhanced performance.
 
 By default, serpack is built to run Javascript/Typescript, but it also supports module bundling!
 

--- a/packages/serpack/README.md
+++ b/packages/serpack/README.md
@@ -1,12 +1,12 @@
 # serpack
 
-Serpack is a JavaScript/TypeScript tool for application development, powered by [swc](https://swc.rs/).
+Serpack is a JavaScript/TypeScript tool for application development, powered by [esbuild](https://esbuild.github.io/).
 
 ```bash
 $ npx serpack ./src/awesome-app.ts # run script
 ```
 
-Serpack is optimized for high-speed bundling and execution of TypeScript files, leveraging [swc](https://swc.rs/) as a transformer and [oxc](https://oxc.rs/) as a resolver for enhanced performance.
+Serpack is optimized for high-speed bundling and execution of TypeScript files, leveraging [esbuild](https://esbuild.github.io/) as a transformer and [oxc](https://oxc.rs/) as a resolver for enhanced performance.
 
 By default, serpack is built to run Javascript/Typescript, but it also supports module bundling!
 

--- a/packages/serpack/package.json
+++ b/packages/serpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serpack",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "bin": "./dist/cli.js",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -26,12 +26,11 @@
   "homepage": "https://zely.vercel.app/serpack",
   "dependencies": {
     "@serpack/logger": "0.0.0",
-    "@swc/core": "^1.10.4",
-    "@swc/helpers": "^0.5.15",
     "acorn": "^8.14.0",
     "animaux": "^0.1.0",
+    "astring": "^1.9.0",
     "deepmerge-ts": "^7.1.5",
-    "escodegen": "^2.1.0",
+    "esbuild": "^0.25.4",
     "estree-walker": "2.0.2",
     "oxc-resolver": "^3.0.3",
     "source-map": "^0.7.4",

--- a/serpack.js
+++ b/serpack.js
@@ -1,0 +1,953 @@
+/* ** This is core package compiled using serpack ** */
+
+(function(modules) {
+  var __serpack_module_cache__={};
+  function __serpack_require__(id){
+    if (!id.startsWith("sp:")) return require(id);
+    if (__serpack_module_cache__[id.slice(3)]) return __serpack_module_cache__[id.slice(3)];
+    const module={exports:{}};
+    __serpack_module_cache__[id.slice(3)]="__serpack_module_pending__";
+    modules[id.slice(3)].call(module.exports, __serpack_require__, require, module, module.exports);
+    __serpack_module_cache__[id.slice(3)]=module.exports;
+    return module.exports;
+  }
+  module.exports=__serpack_require__("sp:0");
+})({
+/* D:\serpack-js\packages\serpack\src\index.ts */ "0": (function(__serpack_require__,__non_serpack_require__,module,exports) { var i = Object.defineProperty;
+var C = Object.getOwnPropertyDescriptor;
+var n = Object.getOwnPropertyNames;
+var s = Object.prototype.hasOwnProperty;
+var O = (m, p) => {
+  for (var e in p) i(m, e, {
+    get: p[e],
+    enumerable: !0
+  });
+}, x = (m, p, e, l) => {
+  if (p && typeof p == "object" || typeof p == "function") for (let f of n(p)) !s.call(m, f) && f !== e && i(m, f, {
+    get: () => p[f],
+    enumerable: !(l = C(p, f)) || l.enumerable
+  });
+  return m;
+}, r = (m, p, e) => (x(m, p, "default"), e && x(e, p, "default"));
+var a = m => x(i({}, "__esModule", {
+  value: !0
+}), m);
+var o = {};
+O(o, {
+  Compiler: () => t.Compiler,
+  CompilerOptions: () => t.CompilerOptions
+});
+module.exports = a(o);
+var t = __serpack_require__("sp:1");
+r(o, __serpack_require__("sp:2"), module.exports);
+r(o, __serpack_require__("sp:3"), module.exports);
+r(o, __serpack_require__("sp:4"), module.exports);
+r(o, __serpack_require__("sp:5"), module.exports);
+r(o, __serpack_require__("sp:6"), module.exports);
+r(o, __serpack_require__("sp:7"), module.exports);
+ }),
+/* D:\serpack-js\packages\serpack\src\core\index.ts */ "1": (function(__serpack_require__,__non_serpack_require__,module,exports) { var w = Object.defineProperty;
+var F = Object.getOwnPropertyDescriptor;
+var K = Object.getOwnPropertyNames;
+var G = Object.prototype.hasOwnProperty;
+var X = (g, e) => {
+  for (var i in e) w(g, i, {
+    get: e[i],
+    enumerable: !0
+  });
+}, H = (g, e, i, r) => {
+  if (e && typeof e == "object" || typeof e == "function") for (let s of K(e)) !G.call(g, s) && s !== i && w(g, s, {
+    get: () => e[s],
+    enumerable: !(r = F(e, s)) || r.enumerable
+  });
+  return g;
+};
+var Q = g => H(w({}, "__esModule", {
+  value: !0
+}), g);
+var W = {};
+X(W, {
+  Compiler: () => q
+});
+module.exports = Q(W);
+var n = __serpack_require__("path"), v = __serpack_require__("fs"), h = __serpack_require__("sp:8"), T = __serpack_require__("acorn"), A = __serpack_require__("oxc-resolver"), M = __serpack_require__("estree-walker"), x = __serpack_require__("source-map"), k = __serpack_require__("deepmerge-ts"), L = __serpack_require__("astring"), J = __serpack_require__("esbuild"), R = __serpack_require__("module"), U = __serpack_require__("sp:3"), a = __serpack_require__("sp:2"), D = __serpack_require__("sp:9"), I = __serpack_require__("sp:10");
+const P = ["cjs", "mjs", "js", "cts", "mts", "ts", "jsx", "tsx"], V = [...P, "json"], B = ["ts", "cts", "mts", "tsx"];
+class q {
+  entry;
+  source;
+  modules;
+  parserOptions;
+  sourceType;
+  resolver;
+  resolverOptions;
+  id;
+  target;
+  constructor(e, i) {
+    ((0, n.isAbsolute)(e) || (e = (0, n.join)(process.cwd(), e)), this.entry = e, this.modules = {}, this.source = (0, v.readFileSync)(e, "utf-8"), this.parserOptions = i || ({}), this.sourceType = B.includes((0, n.parse)(e).ext.slice(1)) ? "typescript" : "javascript", this.resolverOptions = this.parserOptions.resolverOptions || ({}), this.id = {}, this.target = this.parserOptions.target || "node", this.resolver = new A.ResolverFactory({
+      conditionNames: ["node", "import"],
+      mainFields: ["module", "main"],
+      extensions: [".js", ".jsx", ".ts", ".tsx", ".json", ".d.ts"],
+      ...this.resolverOptions
+    }));
+    for (const r of this.pluginArray("onSetup")) {
+      const s = r(this.parserOptions);
+      s && (this.parserOptions = {
+        ...this.parserOptions,
+        ...s
+      });
+    }
+  }
+  pluginArray(e) {
+    var i, r;
+    return ((r = (i = this.parserOptions.plugins) == null ? void 0 : i.map(s => s[e])) != null ? r : []).filter(s => s != null);
+  }
+  async transform(e = this.entry) {
+    var s, c, o, u, m;
+    const i = (0, v.readFileSync)(e, "utf-8");
+    if (!P.includes((0, n.extname)(e).slice(1))) {
+      const t = e.replace(/\\/g, "/");
+      if (((s = this.parserOptions) == null ? void 0 : s.type) === "script") return {
+        code: `module.exports=/*export*/${a.__NON_SERPACK_REQUIRE__}(\`./\${${a.__SERPACK_REQUIRE__}("path").relative(__dirname, "${t}").replace(/\\\\/g, '/')}\`);`,
+        map: {}
+      };
+      if (!((c = this.parserOptions) != null && c.type) || ((o = this.parserOptions) == null ? void 0 : o.type) === "module") {
+        const p = (0, D.load)(t, i);
+        return {
+          code: p.code,
+          map: p.map
+        };
+      }
+      (0, h.error)(`unknown options.type: ${(u = this.parserOptions) == null ? void 0 : u.type}`);
+    }
+    ((m = this.parserOptions) == null ? void 0 : m.type) === "script" && (this.parserOptions.globals || (this.parserOptions.globals = {}), this.parserOptions.globals.vars || (this.parserOptions.globals.vars = {}), this.parserOptions.globals.vars.__filename = JSON.stringify(e), this.parserOptions.globals.vars.__dirname = JSON.stringify((0, n.dirname)(e)));
+    const r = await (0, J.transform)(i, (0, k.deepmerge)({
+      minify: !0,
+      define: {},
+      sourcemap: !0,
+      format: "cjs",
+      loader: "ts",
+      target: "node12"
+    }, {}));
+    if (r.warnings) for (const t of r.warnings) (0, h.warn)(t.text);
+    for await (const t of this.pluginArray("onCompile")) {
+      const p = await t({
+        filename: {
+          original: e,
+          resolved: e
+        },
+        output: r,
+        source: i
+      });
+      (p && p.code && (r.code = p.code), p && p.map && (r.code = p.map));
+    }
+    return {
+      code: r.code,
+      map: JSON.parse(r.map)
+    };
+  }
+  resolve(e = process.cwd(), i) {
+    var o, u, m, t, p;
+    const r = this.resolver.sync(e, i), s = r.path;
+    if (!s) return;
+    for (const l of this.pluginArray("onLoad")) l({
+      filename: {
+        original: i,
+        resolved: s
+      }
+    });
+    const c = (0, n.parse)(s).ext.slice(1);
+    if (V.includes(c)) {
+      if ((u = (o = this.parserOptions) == null ? void 0 : o.forceExternal) != null && u.includes(i)) {
+        (0, h.debug)(`Resolving module: ${s} [rejected - externals]`);
+        return;
+      }
+      if (R.builtinModules.includes(s)) {
+        (0, h.debug)(`Resolving module: ${s} [rejected - builtin]`);
+        return;
+      }
+      if (s != null && s.includes("node_modules")) {
+        if (this.parserOptions.nodeExternal) {
+          (0, h.debug)(`Resolving module: ${s} [rejected - node_modules]`);
+          return;
+        }
+        if (((m = this.parserOptions.externals) == null ? void 0 : m.length) === 0) return s;
+        const l = (0, I.findPackage)(s);
+        if (!l) return s;
+        const d = JSON.parse((0, v.readFileSync)(l).toString()), {name: y} = d;
+        return (t = this.parserOptions.externals) != null && t.includes(y) ? void 0 : s;
+      }
+      return (((p = r.error) == null ? void 0 : p.length) > 0 && console.error(r.error), s);
+    }
+  }
+  async compile(e = this.entry, i = (0, n.join)(process.cwd(), "path")) {
+    const r = this.resolve((0, n.dirname)(i), e);
+    if (!r) {
+      (0, h.warn)(`Cannot resolve module: ${e}`);
+      return;
+    }
+    (e = r, (e in this.id) || (this.id[e] = Object.keys(this.id).length), (0, h.debug)(`Resolving module: ${e}`));
+    const s = await this.transform(e), c = this.parseModule(e, s.code, this.parserOptions);
+    this.modules[e] = {
+      code: (0, L.generate)(c.ast, {}),
+      map: s.map
+    };
+    for await (const o of c.modules) {
+      if (R.builtinModules.includes(o)) continue;
+      const u = this.resolve((0, n.dirname)(e), o);
+      this.modules[u] || await this.compile(o, e);
+    }
+  }
+  parseModule(e, i, r) {
+    const s = i != null ? i : (0, v.readFileSync)(e, "utf-8"), c = (0, T.parse)(s, {
+      sourceType: "module",
+      ecmaVersion: "latest",
+      ...r == null ? void 0 : r.parserOptions
+    }), o = {
+      modules: [],
+      id: this.id
+    }, u = this.resolve.bind(this), m = (0, M.walk)(c, {
+      enter(t) {
+        if (t.type === "CallExpression" && t.callee.type === "Identifier" && t.callee.name === "require" && t.arguments[0].type === "Literal") {
+          const p = t.arguments[0].value, l = u((0, n.dirname)(e), p);
+          if (!l) return (t.callee.name = a.__SERPACK_REQUIRE__, t);
+          (l in o.id) || (o.id[l] = Object.keys(o.id).length);
+          const d = o.id[l];
+          (o.modules.push(p), t.callee.name = a.__SERPACK_REQUIRE__, t.arguments[0].value = `sp:${d}`, t.arguments[0].raw = `"sp:${d}"`, console.log(t.arguments[0]));
+        }
+        if (t.type === "ImportDeclaration" && t.source.type === "Literal") {
+          const p = t.source.value, l = u((0, n.dirname)(e), p);
+          if (!l) return;
+          (l in o.id) || (o.id[l] = Object.keys(o.id).length);
+          const d = o.id[l];
+          (o.modules.push(p), t.source.value = `sp:${d}`, this.replace((0, U.importToRequire)(t)));
+        }
+      },
+      leave(t, p) {
+        var l, d;
+        t.type === "CallExpression" && ((l = r.modifier) != null && l.caller) && (t = ((d = r.modifier) == null ? void 0 : d.caller(t, p)) || t, this.replace(t));
+      }
+    });
+    return (this.id = o.id, {
+      ast: m,
+      modules: o.modules
+    });
+  }
+  async bundle() {
+    var t, p, l, d, y, E;
+    const {modules: e, target: i} = this, r = [], s = new Set(), c = this.parserOptions.sourcemap;
+    let o = 1, u;
+    for await (const O of this.pluginArray("onBundle")) await O();
+    if (((t = this.parserOptions) != null && t.banner && (r.push(this.parserOptions.banner), o += this.parserOptions.banner.split(`
+`).length), (0, h.debug)(`modules: ${JSON.stringify(this.id)}`), c)) {
+      const O = ((l = (p = this.parserOptions) == null ? void 0 : p.sourcemapOptions) == null ? void 0 : l.sourcemapRoot) || (0, n.dirname)(this.entry);
+      u = new x.SourceMapGenerator({
+        file: "bundle.js",
+        sourceRoot: O
+      });
+    }
+    let m = ["(function(modules) {", `  var ${a.__SERPACK_MODULE_CACHE__}={};`, `  function ${a.__SERPACK_REQUIRE__}(id){`, '    if (!id.startsWith("sp:")) return require(id);', `    if (${a.__SERPACK_MODULE_CACHE__}[id.slice(3)]) return ${a.__SERPACK_MODULE_CACHE__}[id.slice(3)];`, "    const module={exports:{}};", `    ${a.__SERPACK_MODULE_CACHE__}[id.slice(3)]="${a.__SERPACK_MODULE_PENDING__}";`, `    modules[id.slice(3)].call(module.exports, ${a.__SERPACK_REQUIRE__}, ${a.__NON_SERPACK_REQUIRE__}, module, module.exports);`, `    ${a.__SERPACK_MODULE_CACHE__}[id.slice(3)]=module.exports;`, "    return module.exports;", "  }", `  module.exports=${a.__SERPACK_REQUIRE__}("sp:0");`, "})({"];
+    (i === "browser" && m.unshift("/*browser-support*/", "var module={exports:{}};", 'function require(id){throw new Error(`Cannot find module "${id}"`);}'), this.parserOptions.runtime && (m = [`  var ${a.__SERPACK_ENV__}=${JSON.stringify({
+      target: this.target
+    })};`, `  ${this.target === "node" ? "process.env" : "window"}.__RUNTIME__=JSON.stringify(${a.__SERPACK_ENV__});`, "module.exports=({"]), r.push(...m), o += m.length);
+    for await (const [O, $] of Object.entries(e)) {
+      const C = `/* ${O} */ "${this.id[O]}": (function(${a.__SERPACK_REQUIRE__},__non_serpack_require__,module,exports) { `, S = `${C}${$.code} }),`;
+      if ((r.push(S), c && Object.keys($.map).length > 0)) {
+        const b = await new x.SourceMapConsumer($.map), j = ((y = (d = this.parserOptions) == null ? void 0 : d.sourcemapOptions) == null ? void 0 : y.sourcemapRoot) || (0, n.dirname)(this.entry);
+        (b.eachMapping(_ => {
+          if (_.source) {
+            let f = _.source;
+            if (((0, n.isAbsolute)(f) ? f = (0, n.relative)(j, f) : f = (0, n.relative)(j, (0, n.join)((0, n.dirname)(O), f)), f = f.replace(/\\/g, "/"), u.addMapping({
+              source: f,
+              original: {
+                line: _.originalLine,
+                column: _.originalColumn
+              },
+              generated: {
+                line: o,
+                column: _.generatedColumn + C.length
+              },
+              name: _.name
+            }), !s.has(f))) {
+              const N = b.sourceContentFor(_.source, !0);
+              N && (u.setSourceContent(f, N), s.add(f));
+            }
+          }
+        }), b.destroy());
+      }
+      o += S.split(`
+`).length;
+    }
+    return (r.push("});"), o += 1, (E = this.parserOptions) != null && E.footer && (r.push(this.parserOptions.footer), o += this.parserOptions.footer.split(`
+`).length), {
+      code: r.join(`
+`),
+      map: c ? u.toString() : null
+    });
+  }
+}
+ }),
+/* D:\serpack-js\packages\serpack-logger\dist\index.mjs */ "8": (function(__serpack_require__,__non_serpack_require__,module,exports) { var c = Object.defineProperty;
+var R = Object.getOwnPropertyDescriptor;
+var g = Object.getOwnPropertyNames;
+var N = Object.prototype.hasOwnProperty;
+var b = (e, r) => {
+  for (var o in r) c(e, o, {
+    get: r[o],
+    enumerable: !0
+  });
+}, d = (e, r, o, i) => {
+  if (r && typeof r == "object" || typeof r == "function") for (let n of g(r)) !N.call(e, n) && n !== o && c(e, n, {
+    get: () => r[n],
+    enumerable: !(i = R(r, n)) || i.enumerable
+  });
+  return e;
+};
+var p = e => d(c({}, "__esModule", {
+  value: !0
+}), e);
+var v = {};
+b(v, {
+  COMPILER_LOG_LEVEL_TYPE: () => t,
+  debug: () => s,
+  error: () => a,
+  info: () => l,
+  warn: () => f
+});
+module.exports = p(v);
+var A = __serpack_require__("colors"), t = (e => (e[e.ERROR = 0] = "ERROR", e[e.WARN = 1] = "WARN", e[e.INFO = 2] = "INFO", e[e.DEBUG = 3] = "DEBUG", e))(t || ({}));
+process.argv.includes("--compiler-debug") && (global.COMPILER_LOG_LEVEL = "debug");
+function U(e) {
+  if (!e) return 2;
+  switch (e.toUpperCase()) {
+    case "ERROR":
+      return 0;
+    case "WARN":
+      return 1;
+    case "INFO":
+      return 2;
+    case "DEBUG":
+      return 3;
+    default:
+      return 2;
+  }
+}
+var u = U(global.COMPILER_LOG_LEVEL);
+function a(e) {
+  u >= 0 && console.error(`[ERROR]: ${e}`.red);
+}
+function f(e) {
+  u >= 1 && console.warn(`[WARN]: ${e}`.yellow);
+}
+function l(e) {
+  u >= 2 && console.info(`[INFO]: ${e}`.blue);
+}
+function s(e) {
+  u >= 3 && console.debug(`[DEBUG]: ${e}`.cyan);
+}
+ }),
+/* D:\serpack-js\packages\serpack\src\core\parse.ts */ "3": (function(__serpack_require__,__non_serpack_require__,module,exports) { var o = Object.defineProperty;
+var c = Object.getOwnPropertyDescriptor;
+var f = Object.getOwnPropertyNames;
+var m = Object.prototype.hasOwnProperty;
+var y = (t, e) => {
+  for (var r in e) o(t, r, {
+    get: e[r],
+    enumerable: !0
+  });
+}, d = (t, e, r, a) => {
+  if (e && typeof e == "object" || typeof e == "function") for (let n of f(e)) !m.call(t, n) && n !== r && o(t, n, {
+    get: () => e[n],
+    enumerable: !(a = c(e, n)) || a.enumerable
+  });
+  return t;
+};
+var u = t => d(o({}, "__esModule", {
+  value: !0
+}), t);
+var x = {};
+y(x, {
+  importToRequire: () => I
+});
+module.exports = u(x);
+function I(t) {
+  if (t.type === "ImportDeclaration") {
+    const {specifiers: e, source: r} = t;
+    if (e.length === 0) return {
+      type: "ExpressionStatement",
+      expression: {
+        type: "CallExpression",
+        optional: !1,
+        callee: {
+          type: "Identifier",
+          name: "require"
+        },
+        arguments: [r]
+      }
+    };
+    if (e.length === 1) {
+      const a = e[0], {name: n} = a.local;
+      if (a.type === "ImportDefaultSpecifier" || a.type === "ImportNamespaceSpecifier") return {
+        type: "VariableDeclaration",
+        kind: "const",
+        declarations: [{
+          type: "VariableDeclarator",
+          id: {
+            type: "Identifier",
+            name: n
+          },
+          init: {
+            type: "CallExpression",
+            optional: !1,
+            callee: {
+              type: "Identifier",
+              name: "require"
+            },
+            arguments: [r]
+          }
+        }]
+      };
+    }
+    if (e.length > 1) {
+      const a = e.find(i => i.type === "ImportDefaultSpecifier"), n = e.filter(i => i.type === "ImportSpecifier"), p = [];
+      if (a) {
+        const {name: i} = a.local;
+        p.push({
+          type: "VariableDeclarator",
+          id: {
+            type: "Identifier",
+            name: i
+          },
+          init: {
+            type: "CallExpression",
+            optional: !1,
+            callee: {
+              type: "Identifier",
+              name: "require"
+            },
+            arguments: [r]
+          }
+        });
+      }
+      for (const i of n) {
+        const {name: l} = i.local, s = i.imported && i.imported.type === "Identifier" ? i.imported.name : "";
+        p.push({
+          type: "VariableDeclarator",
+          id: {
+            type: "Identifier",
+            name: l
+          },
+          init: {
+            type: "MemberExpression",
+            object: {
+              type: "CallExpression",
+              optional: !1,
+              callee: {
+                type: "Identifier",
+                name: "require"
+              },
+              arguments: [r]
+            },
+            property: {
+              type: "Identifier",
+              name: s
+            },
+            computed: !1
+          }
+        });
+      }
+      return {
+        type: "VariableDeclaration",
+        kind: "const",
+        declarations: p
+      };
+    }
+  }
+  return t;
+}
+ }),
+/* D:\serpack-js\packages\serpack\src\core\functions.ts */ "2": (function(__serpack_require__,__non_serpack_require__,module,exports) { var r = Object.defineProperty;
+var t = Object.getOwnPropertyDescriptor;
+var p = Object.getOwnPropertyNames;
+var s = Object.prototype.hasOwnProperty;
+var n = (e, _) => {
+  for (var o in _) r(e, o, {
+    get: _[o],
+    enumerable: !0
+  });
+}, R = (e, _, o, c) => {
+  if (_ && typeof _ == "object" || typeof _ == "function") for (let E of p(_)) !s.call(e, E) && E !== o && r(e, E, {
+    get: () => _[E],
+    enumerable: !(c = t(_, E)) || c.enumerable
+  });
+  return e;
+};
+var C = e => R(r({}, "__esModule", {
+  value: !0
+}), e);
+var N = {};
+n(N, {
+  __ESM__: () => P,
+  __NON_SERPACK_REQUIRE__: () => A,
+  __SERPACK_ENV__: () => K,
+  __SERPACK_MODULE_CACHE__: () => S,
+  __SERPACK_MODULE_PENDING__: () => a,
+  __SERPACK_REQUIRE__: () => x
+});
+module.exports = C(N);
+const x = "__serpack_require__", A = "require", P = "__esm__", S = "__serpack_module_cache__", a = "__serpack_module_pending__", K = "__serpack_env__";
+ }),
+/* D:\serpack-js\packages\serpack\src\core\loader.ts */ "9": (function(__serpack_require__,__non_serpack_require__,module,exports) { var i = Object.defineProperty;
+var l = Object.getOwnPropertyDescriptor;
+var m = Object.getOwnPropertyNames;
+var f = Object.prototype.hasOwnProperty;
+var d = (e, n) => {
+  for (var t in n) i(e, t, {
+    get: n[t],
+    enumerable: !0
+  });
+}, $ = (e, n, t, o) => {
+  if (n && typeof n == "object" || typeof n == "function") for (let r of m(n)) !f.call(e, r) && r !== t && i(e, r, {
+    get: () => n[r],
+    enumerable: !(o = l(n, r)) || o.enumerable
+  });
+  return e;
+};
+var x = e => $(i({}, "__esModule", {
+  value: !0
+}), e);
+var j = {};
+d(j, {
+  load: () => h
+});
+module.exports = x(j);
+var c = __serpack_require__("path"), p = __serpack_require__("sp:8"), s = __serpack_require__("vlq");
+function S(e) {
+  let n = 0, t = "";
+  (t += (0, s.encode)([n, 0, 0, 0]), n += 15, t += `,${(0, s.encode)([0, 0, 0, 0])}`);
+  const o = Object.entries(e);
+  return (o.forEach(([r, u], a) => {
+    (t += `,${(0, s.encode)([1, 0, 0, n])}`, n += r.length + 2, n += 2);
+    const g = JSON.stringify(u);
+    (t += `,${(0, s.encode)([1, 0, 0, n])}`, n += g.length, a < o.length - 1 && (n += 2));
+  }), t);
+}
+function O(e, n) {
+  const t = JSON.parse(n);
+  return {
+    version: 3,
+    file: e,
+    sources: [e],
+    names: [],
+    sourcesContent: [n],
+    mappings: S(t),
+    sourceRoot: ""
+  };
+}
+function h(e, n) {
+  const t = (0, c.extname)(e).slice(1);
+  return t === "json" ? {
+    code: `module.exports=${n};`,
+    map: O(e, n)
+  } : ((0, p.warn)(`Unsupported extension: .${t} (file: ${e})`), {
+    code: "",
+    map: null
+  });
+}
+ }),
+/* D:\serpack-js\packages\serpack\src\lib\root.ts */ "10": (function(__serpack_require__,__non_serpack_require__,module,exports) { var o = Object.defineProperty;
+var u = Object.getOwnPropertyDescriptor;
+var c = Object.getOwnPropertyNames;
+var p = Object.prototype.hasOwnProperty;
+var f = (r, n) => {
+  for (var i in n) o(r, i, {
+    get: n[i],
+    enumerable: !0
+  });
+}, g = (r, n, i, s) => {
+  if (n && typeof n == "object" || typeof n == "function") for (let e of c(n)) !p.call(r, e) && e !== i && o(r, e, {
+    get: () => n[e],
+    enumerable: !(s = u(n, e)) || s.enumerable
+  });
+  return r;
+};
+var m = r => g(o({}, "__esModule", {
+  value: !0
+}), r);
+var j = {};
+f(j, {
+  findPackage: () => d
+});
+module.exports = m(j);
+var a = __serpack_require__("fs"), t = __serpack_require__("path");
+function l(r) {
+  if (!r || r.length === 0) return null;
+  const n = (0, t.join)(...r);
+  if ((0, a.existsSync)((0, t.join)(n, "package.json"))) return (0, t.join)(n, "package.json");
+  const i = (0, t.parse)(n).dir;
+  return n === i ? null : l(i.split(t.sep));
+}
+function d(r) {
+  const i = (0, t.normalize)(r).split(t.sep);
+  return l(i);
+}
+ }),
+/* D:\serpack-js\packages\serpack\src\config.ts */ "4": (function(__serpack_require__,__non_serpack_require__,module,exports) { var j = Object.create;
+var a = Object.defineProperty;
+var O = Object.getOwnPropertyDescriptor;
+var d = Object.getOwnPropertyNames;
+var _ = Object.getPrototypeOf, v = Object.prototype.hasOwnProperty;
+var w = (t, o) => {
+  for (var r in o) a(t, r, {
+    get: o[r],
+    enumerable: !0
+  });
+}, u = (t, o, r, e) => {
+  if (o && typeof o == "object" || typeof o == "function") for (let s of d(o)) !v.call(t, s) && s !== r && a(t, s, {
+    get: () => o[s],
+    enumerable: !(e = O(o, s)) || e.enumerable
+  });
+  return t;
+};
+var c = (t, o, r) => (r = t != null ? j(_(t)) : {}, u(o || !t || !t.__esModule ? a(r, "default", {
+  value: t,
+  enumerable: !0
+}) : r, t)), S = t => u(a({}, "__esModule", {
+  value: !0
+}), t);
+var x = {};
+w(x, {
+  defineConfig: () => h,
+  loadConfig: () => C
+});
+module.exports = S(x);
+var p = __serpack_require__("sp:8"), n = __serpack_require__("fs"), i = __serpack_require__("path"), l = __serpack_require__("sp:5"), y = __serpack_require__("sp:11");
+function h(t) {
+  return t;
+}
+async function k(t = process.cwd()) {
+  const o = {
+    json: [".serpackrc", ".serpackrc.json"],
+    js: [".serpackrc.js"],
+    ts: [".serpackrc.ts"]
+  };
+  (o.json = o.json.map(r => (0, i.join)(t, r)), o.js = o.js.map(r => (0, i.join)(t, r)), o.ts = o.ts.map(r => (0, i.join)(t, r)));
+  for (const r of o.json) try {
+    if ((0, n.existsSync)(r)) {
+      const e = (0, n.readFileSync)(r, "utf-8");
+      return JSON.parse(e);
+    }
+  } catch (e) {
+    (0, p.error)(e);
+  }
+  for await (const r of o.js) {
+    const e = `./${(0, i.relative)(__dirname, r).replace(/\\/g, "/")}`;
+    if ((0, n.existsSync)(r)) try {
+      return require(e);
+    } catch {
+      return await Promise.resolve().then(() => c(require(e)));
+    }
+  }
+  for await (const r of o.ts) try {
+    if ((0, n.existsSync)(r)) {
+      const e = await (0, l.compile)(r, {
+        globals: {
+          vars: {
+            __dirname: JSON.stringify((0, i.dirname)(r)),
+            __filename: JSON.stringify(r)
+          }
+        }
+      }), s = (0, i.join)(process.cwd(), "scfg.js");
+      (0, n.writeFileSync)(s, e.code);
+      const f = `./${(0, i.relative)(__dirname, s).replace(/\\/g, "/")}`;
+      try {
+        const m = require(f);
+        return ((0, n.rmSync)(s), m);
+      } catch {
+        const g = await Promise.resolve().then(() => c(require(f)));
+        return ((0, n.rmSync)(s), g);
+      }
+    }
+  } catch (e) {
+    (0, p.error)(e);
+  }
+  return {};
+}
+async function C(t = process.cwd()) {
+  (0, i.isAbsolute)(t) || (t = (0, i.join)(process.cwd(), t));
+  const o = await k(t);
+  return (0, y.__importDefault)(o);
+}
+ }),
+/* D:\serpack-js\packages\serpack\src\compile.ts */ "5": (function(__serpack_require__,__non_serpack_require__,module,exports) { var m = Object.defineProperty;
+var l = Object.getOwnPropertyDescriptor;
+var s = Object.getOwnPropertyNames;
+var a = Object.prototype.hasOwnProperty;
+var u = (e, o) => {
+  for (var n in o) m(e, n, {
+    get: o[n],
+    enumerable: !0
+  });
+}, d = (e, o, n, p) => {
+  if (o && typeof o == "object" || typeof o == "function") for (let i of s(o)) !a.call(e, i) && i !== n && m(e, i, {
+    get: () => o[i],
+    enumerable: !(p = l(o, i)) || p.enumerable
+  });
+  return e;
+};
+var f = e => d(m({}, "__esModule", {
+  value: !0
+}), e);
+var w = {};
+u(w, {
+  compile: () => c
+});
+module.exports = f(w);
+var r = __serpack_require__("sp:8"), t = __serpack_require__("sp:1");
+async function c(e, o) {
+  const n = performance.now(), p = new t.Compiler(e, o);
+  await p.compile(e);
+  const i = await p.bundle();
+  return ((0, r.debug)(`Compiled Successfully in ${(performance.now() - n).toFixed()}ms`), {
+    code: i.code,
+    map: i.map
+  });
+}
+ }),
+/* D:\serpack-js\packages\serpack\src\runtime\index.ts */ "11": (function(__serpack_require__,__non_serpack_require__,module,exports) { var a = Object.defineProperty;
+var b = Object.getOwnPropertyDescriptor;
+var c = Object.getOwnPropertyNames;
+var d = Object.prototype.hasOwnProperty;
+var t = (f, e, p, x) => {
+  if (e && typeof e == "object" || typeof e == "function") for (let m of c(e)) !d.call(f, m) && m !== p && a(f, m, {
+    get: () => e[m],
+    enumerable: !(x = b(e, m)) || x.enumerable
+  });
+  return f;
+}, r = (f, e, p) => (t(f, e, "default"), p && t(p, e, "default"));
+var g = f => t(a({}, "__esModule", {
+  value: !0
+}), f);
+var o = {};
+module.exports = g(o);
+r(o, __serpack_require__("sp:12"), module.exports);
+r(o, __serpack_require__("sp:13"), module.exports);
+r(o, __serpack_require__("sp:14"), module.exports);
+r(o, __serpack_require__("sp:15"), module.exports);
+ }),
+/* D:\serpack-js\packages\serpack\src\runtime\require.ts */ "12": (function(__serpack_require__,__non_serpack_require__,module,exports) { var _ = Object.defineProperty;
+var f = Object.getOwnPropertyDescriptor;
+var i = Object.getOwnPropertyNames;
+var l = Object.prototype.hasOwnProperty;
+var m = (t, e) => {
+  for (var n in e) _(t, n, {
+    get: e[n],
+    enumerable: !0
+  });
+}, x = (t, e, n, u) => {
+  if (e && typeof e == "object" || typeof e == "function") for (let r of i(e)) !l.call(t, r) && r !== n && _(t, r, {
+    get: () => e[r],
+    enumerable: !(u = f(e, r)) || u.enumerable
+  });
+  return t;
+};
+var q = t => x(_({}, "__esModule", {
+  value: !0
+}), t);
+var R = {};
+m(R, {
+  createBrowserRequire: () => p,
+  createNodeRequire: () => a,
+  createRequire: () => w
+});
+module.exports = q(R);
+var c = __serpack_require__("sp:2"), s = __serpack_require__("sp:13");
+function a(t) {
+  const e = {};
+  function n(r) {
+    const o = {
+      exports: {}
+    };
+    return (e[r] = c.__SERPACK_MODULE_PENDING__, t[r].call(o.exports, u, require, o, o.exports), e[r] = o.exports, o.exports);
+  }
+  function u(r) {
+    return t[r] ? n(r) : r.startsWith("sp:") ? (r = r.slice(3), e[r] ? e[r] : n(r)) : require(r);
+  }
+  return u;
+}
+function p(t) {
+  const e = {}, n = r => {
+    throw new Error(`Cannot find module "${r}"`);
+  };
+  function u(r) {
+    if (!r.startsWith("sp:")) throw new Error(`Cannot find module "${r}"`);
+    if ((r = r.slice(3), e[r])) return e[r];
+    const o = {
+      exports: {}
+    };
+    return (e[r] = c.__SERPACK_MODULE_PENDING__, t[r].call(o.exports, u, n, o, o.exports), e[r] = o.exports, o.exports);
+  }
+  return u;
+}
+function w(t) {
+  var n;
+  return ((n = (0, s.env)()) == null ? void 0 : n.target) === "browser" ? p(t) : a(t);
+}
+ }),
+/* D:\serpack-js\packages\serpack\src\runtime\env.ts */ "13": (function(__serpack_require__,__non_serpack_require__,module,exports) { var i = Object.defineProperty;
+var o = Object.getOwnPropertyDescriptor;
+var R = Object.getOwnPropertyNames;
+var p = Object.prototype.hasOwnProperty;
+var d = (e, n) => {
+  for (var r in n) i(e, r, {
+    get: n[r],
+    enumerable: !0
+  });
+}, f = (e, n, r, u) => {
+  if (n && typeof n == "object" || typeof n == "function") for (let t of R(n)) !p.call(e, t) && t !== r && i(e, t, {
+    get: () => n[t],
+    enumerable: !(u = o(n, t)) || u.enumerable
+  });
+  return e;
+};
+var s = e => f(i({}, "__esModule", {
+  value: !0
+}), e);
+var E = {};
+d(E, {
+  env: () => y
+});
+module.exports = s(E);
+function y(e) {
+  var n;
+  if (!e) {
+    if (typeof process < "u" && ((n = process == null ? void 0 : process.env) != null && n.__RUNTIME__)) return JSON.parse(process.env.__RUNTIME__);
+    if (typeof window < "u" && (window != null && window.__RUNTIME__)) return JSON.parse(window.__RUNTIME__);
+  }
+  return typeof e == "string" ? JSON.parse(e) : e;
+}
+ }),
+/* D:\serpack-js\packages\serpack\src\runtime\runtime.ts */ "14": (function(__serpack_require__,__non_serpack_require__,module,exports) { var i = Object.defineProperty;
+var l = Object.getOwnPropertyDescriptor;
+var c = Object.getOwnPropertyNames;
+var p = Object.prototype.hasOwnProperty;
+var m = (r, e) => {
+  for (var u in e) i(r, u, {
+    get: e[u],
+    enumerable: !0
+  });
+}, a = (r, e, u, t) => {
+  if (e && typeof e == "object" || typeof e == "function") for (let o of c(e)) !p.call(r, o) && o !== u && i(r, o, {
+    get: () => e[o],
+    enumerable: !(t = l(e, o)) || t.enumerable
+  });
+  return r;
+};
+var M = r => a(i({}, "__esModule", {
+  value: !0
+}), r);
+var q = {};
+m(q, {
+  Runtime: () => _,
+  createRuntime: () => y
+});
+module.exports = M(q);
+var s = __serpack_require__("path"), n = __serpack_require__("sp:12");
+class _ {
+  __modules__;
+  require;
+  constructor(e) {
+    (this.__modules__ = e, this.require = (0, n.createNodeRequire)(e));
+  }
+  loadModule(e) {
+    return this.require(e);
+  }
+}
+function y(r) {
+  const e = (0, s.isAbsolute)(r) ? r : (0, s.resolve)(r), u = require(e), t = new _(u);
+  return {
+    runtime: t,
+    execute() {
+      return t.loadModule("sp:0");
+    },
+    createExternalModule(o, d) {
+      t.__modules__[o] = d;
+    }
+  };
+}
+ }),
+/* D:\serpack-js\packages\serpack\src\runtime\resolve-esm.ts */ "15": (function(__serpack_require__,__non_serpack_require__,module,exports) { var n = Object.defineProperty;
+var _ = Object.getOwnPropertyDescriptor;
+var a = Object.getOwnPropertyNames;
+var i = Object.prototype.hasOwnProperty;
+var l = (e, t) => {
+  for (var u in t) n(e, u, {
+    get: t[u],
+    enumerable: !0
+  });
+}, o = (e, t, u, f) => {
+  if (t && typeof t == "object" || typeof t == "function") for (let r of a(t)) !i.call(e, r) && r !== u && n(e, r, {
+    get: () => t[r],
+    enumerable: !(f = _(t, r)) || f.enumerable
+  });
+  return e;
+};
+var p = e => o(n({}, "__esModule", {
+  value: !0
+}), e);
+var s = {};
+l(s, {
+  __importDefault: () => c
+});
+module.exports = p(s);
+function c(e) {
+  return e.__esModule ? e.default : e;
+}
+ }),
+/* D:\serpack-js\packages\serpack\src\plugin.ts */ "6": (function(__serpack_require__,__non_serpack_require__,module,exports) { var e = Object.defineProperty;
+var r = Object.getOwnPropertyDescriptor;
+var l = Object.getOwnPropertyNames;
+var m = Object.prototype.hasOwnProperty;
+var u = (t, o, p, n) => {
+  if (o && typeof o == "object" || typeof o == "function") for (let i of l(o)) !m.call(t, i) && i !== p && e(t, i, {
+    get: () => o[i],
+    enumerable: !(n = r(o, i)) || n.enumerable
+  });
+  return t;
+};
+var C = t => u(e({}, "__esModule", {
+  value: !0
+}), t);
+var g = {};
+module.exports = C(g);
+ }),
+/* D:\serpack-js\packages\serpack\src\dependencies.ts */ "7": (function(__serpack_require__,__non_serpack_require__,module,exports) { var i = Object.defineProperty;
+var s = Object.getOwnPropertyDescriptor;
+var c = Object.getOwnPropertyNames;
+var m = Object.prototype.hasOwnProperty;
+var l = (o, e) => {
+  for (var r in e) i(o, r, {
+    get: e[r],
+    enumerable: !0
+  });
+}, u = (o, e, r, n) => {
+  if (e && typeof e == "object" || typeof e == "function") for (let t of c(e)) !m.call(o, t) && t !== r && i(o, t, {
+    get: () => e[t],
+    enumerable: !(n = s(e, t)) || n.enumerable
+  });
+  return o;
+};
+var a = o => u(i({}, "__esModule", {
+  value: !0
+}), o);
+var C = {};
+l(C, {
+  getDependencies: () => d
+});
+module.exports = a(C);
+var p = __serpack_require__("sp:1");
+async function d(o, e) {
+  const r = new p.Compiler(o, e || ({}));
+  return (await r.parseModule(o), Object.keys(r.modules));
+}
+ }),
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
   integrity sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==
 
+"@esbuild/aix-ppc64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz#830d6476cbbca0c005136af07303646b419f1162"
+  integrity sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==
+
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"
@@ -38,6 +43,11 @@
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz#09d9b4357780da9ea3a7dfb833a1f1ff439b4052"
   integrity sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==
+
+"@esbuild/android-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz#d11d4fc299224e729e2190cacadbcc00e7a9fd67"
+  integrity sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==
 
 "@esbuild/android-arm@0.18.20":
   version "0.18.20"
@@ -49,6 +59,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.21.5.tgz#9b04384fb771926dfa6d7ad04324ecb2ab9b2e28"
   integrity sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==
 
+"@esbuild/android-arm@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.4.tgz#5660bd25080553dd2a28438f2a401a29959bd9b1"
+  integrity sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==
+
 "@esbuild/android-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.18.20.tgz#35cf419c4cfc8babe8893d296cd990e9e9f756f2"
@@ -58,6 +73,11 @@
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.21.5.tgz#29918ec2db754cedcb6c1b04de8cd6547af6461e"
   integrity sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==
+
+"@esbuild/android-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.4.tgz#18ddde705bf984e8cd9efec54e199ac18bc7bee1"
+  integrity sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==
 
 "@esbuild/darwin-arm64@0.18.20":
   version "0.18.20"
@@ -69,6 +89,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz#e495b539660e51690f3928af50a76fb0a6ccff2a"
   integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
 
+"@esbuild/darwin-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz#b0b7fb55db8fc6f5de5a0207ae986eb9c4766e67"
+  integrity sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==
+
 "@esbuild/darwin-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz#d70d5790d8bf475556b67d0f8b7c5bdff053d85d"
@@ -78,6 +103,11 @@
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz#c13838fa57372839abdddc91d71542ceea2e1e22"
   integrity sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
+
+"@esbuild/darwin-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz#e6813fdeba0bba356cb350a4b80543fbe66bf26f"
+  integrity sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==
 
 "@esbuild/freebsd-arm64@0.18.20":
   version "0.18.20"
@@ -89,6 +119,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz#646b989aa20bf89fd071dd5dbfad69a3542e550e"
   integrity sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==
 
+"@esbuild/freebsd-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz#dc11a73d3ccdc308567b908b43c6698e850759be"
+  integrity sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==
+
 "@esbuild/freebsd-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz#c1eb2bff03915f87c29cece4c1a7fa1f423b066e"
@@ -98,6 +133,11 @@
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz#aa615cfc80af954d3458906e38ca22c18cf5c261"
   integrity sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==
+
+"@esbuild/freebsd-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz#91da08db8bd1bff5f31924c57a81dab26e93a143"
+  integrity sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==
 
 "@esbuild/linux-arm64@0.18.20":
   version "0.18.20"
@@ -109,6 +149,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz#70ac6fa14f5cb7e1f7f887bcffb680ad09922b5b"
   integrity sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
 
+"@esbuild/linux-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz#efc15e45c945a082708f9a9f73bfa8d4db49728a"
+  integrity sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==
+
 "@esbuild/linux-arm@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz#3e617c61f33508a27150ee417543c8ab5acc73b0"
@@ -118,6 +163,11 @@
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz#fc6fd11a8aca56c1f6f3894f2bea0479f8f626b9"
   integrity sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==
+
+"@esbuild/linux-arm@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz#9b93c3e54ac49a2ede6f906e705d5d906f6db9e8"
+  integrity sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==
 
 "@esbuild/linux-ia32@0.18.20":
   version "0.18.20"
@@ -129,6 +179,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz#3271f53b3f93e3d093d518d1649d6d68d346ede2"
   integrity sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==
 
+"@esbuild/linux-ia32@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz#be8ef2c3e1d99fca2d25c416b297d00360623596"
+  integrity sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==
+
 "@esbuild/linux-loong64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz#e6fccb7aac178dd2ffb9860465ac89d7f23b977d"
@@ -138,6 +193,11 @@
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz#ed62e04238c57026aea831c5a130b73c0f9f26df"
   integrity sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==
+
+"@esbuild/linux-loong64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz#b0840a2707c3fc02eec288d3f9defa3827cd7a87"
+  integrity sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==
 
 "@esbuild/linux-mips64el@0.18.20":
   version "0.18.20"
@@ -149,6 +209,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz#e79b8eb48bf3b106fadec1ac8240fb97b4e64cbe"
   integrity sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==
 
+"@esbuild/linux-mips64el@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz#2a198e5a458c9f0e75881a4e63d26ba0cf9df39f"
+  integrity sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==
+
 "@esbuild/linux-ppc64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz#2f7156bde20b01527993e6881435ad79ba9599fb"
@@ -158,6 +223,11 @@
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz#5f2203860a143b9919d383ef7573521fb154c3e4"
   integrity sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==
+
+"@esbuild/linux-ppc64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz#64f4ae0b923d7dd72fb860b9b22edb42007cf8f5"
+  integrity sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==
 
 "@esbuild/linux-riscv64@0.18.20":
   version "0.18.20"
@@ -169,6 +239,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz#07bcafd99322d5af62f618cb9e6a9b7f4bb825dc"
   integrity sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==
 
+"@esbuild/linux-riscv64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz#fb2844b11fdddd39e29d291c7cf80f99b0d5158d"
+  integrity sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==
+
 "@esbuild/linux-s390x@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz#255e81fb289b101026131858ab99fba63dcf0071"
@@ -178,6 +253,11 @@
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz#b7ccf686751d6a3e44b8627ababc8be3ef62d8de"
   integrity sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==
+
+"@esbuild/linux-s390x@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz#1466876e0aa3560c7673e63fdebc8278707bc750"
+  integrity sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==
 
 "@esbuild/linux-x64@0.18.20":
   version "0.18.20"
@@ -189,6 +269,16 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz#6d8f0c768e070e64309af8004bb94e68ab2bb3b0"
   integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
 
+"@esbuild/linux-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz#c10fde899455db7cba5f11b3bccfa0e41bf4d0cd"
+  integrity sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==
+
+"@esbuild/netbsd-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz#02e483fbcbe3f18f0b02612a941b77be76c111a4"
+  integrity sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==
+
 "@esbuild/netbsd-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz#30e8cd8a3dded63975e2df2438ca109601ebe0d1"
@@ -198,6 +288,16 @@
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz#bbe430f60d378ecb88decb219c602667387a6047"
   integrity sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==
+
+"@esbuild/netbsd-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz#ec401fb0b1ed0ac01d978564c5fc8634ed1dc2ed"
+  integrity sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==
+
+"@esbuild/openbsd-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz#f272c2f41cfea1d91b93d487a51b5c5ca7a8c8c4"
+  integrity sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==
 
 "@esbuild/openbsd-x64@0.18.20":
   version "0.18.20"
@@ -209,6 +309,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz#99d1cf2937279560d2104821f5ccce220cb2af70"
   integrity sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==
 
+"@esbuild/openbsd-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz#2e25950bc10fa9db1e5c868e3d50c44f7c150fd7"
+  integrity sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==
+
 "@esbuild/sunos-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz#d5c275c3b4e73c9b0ecd38d1ca62c020f887ab9d"
@@ -218,6 +323,11 @@
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz#08741512c10d529566baba837b4fe052c8f3487b"
   integrity sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==
+
+"@esbuild/sunos-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz#cd596fa65a67b3b7adc5ecd52d9f5733832e1abd"
+  integrity sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==
 
 "@esbuild/win32-arm64@0.18.20":
   version "0.18.20"
@@ -229,6 +339,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz#675b7385398411240735016144ab2e99a60fc75d"
   integrity sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==
 
+"@esbuild/win32-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz#b4dbcb57b21eeaf8331e424c3999b89d8951dc88"
+  integrity sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==
+
 "@esbuild/win32-ia32@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz#ec93cbf0ef1085cc12e71e0d661d20569ff42102"
@@ -239,6 +354,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz#1bfc3ce98aa6ca9a0969e4d2af72144c59c1193b"
   integrity sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==
 
+"@esbuild/win32-ia32@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz#410842e5d66d4ece1757634e297a87635eb82f7a"
+  integrity sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==
+
 "@esbuild/win32-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
@@ -248,6 +368,11 @@
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
   integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
+
+"@esbuild/win32-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz#0b17ec8a70b2385827d52314c1253160a0b9bacc"
+  integrity sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.5.1"
@@ -682,7 +807,7 @@
   resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.13.tgz#0412620d8594a7d3e482d3e79d9e89d80f9a14c0"
   integrity sha512-+X5/uW3s1L5gK7wAo0E27YaAoidJDo51dnfKSfU7gF3mlEUuWH8H1bAy5OTt2mU4eXtfsdUMEVXSwhDlLtQkuA==
 
-"@swc/core@^1.10.4", "@swc/core@^1.7.3":
+"@swc/core@^1.7.3":
   version "1.11.13"
   resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.11.13.tgz#54ca047c7139d35e358a16a5afcbf8aec0d6e8b6"
   integrity sha512-9BXdYz12Wl0zWmZ80PvtjBWeg2ncwJ9L5WJzjhN6yUTZWEV/AwAdVdJnIEp4pro3WyKmAaMxcVOSbhuuOZco5g==
@@ -705,13 +830,6 @@
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.3.tgz#cc7463bd02949611c6329596fccd2b0ec782b0e9"
   integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
-
-"@swc/helpers@^0.5.15":
-  version "0.5.15"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.15.tgz#79efab344c5819ecf83a43f3f9f811fc84b516d7"
-  integrity sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==
-  dependencies:
-    tslib "^2.8.0"
 
 "@swc/types@^0.1.19":
   version "0.1.19"
@@ -1041,6 +1159,11 @@ assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
   integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
+astring@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/astring/-/astring-1.9.0.tgz#cc73e6062a7eb03e7d19c22d8b0b3451fd9bfeef"
+  integrity sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==
 
 async-function@^1.0.0:
   version "1.0.0"
@@ -1481,6 +1604,37 @@ esbuild@^0.21.3:
     "@esbuild/win32-arm64" "0.21.5"
     "@esbuild/win32-ia32" "0.21.5"
     "@esbuild/win32-x64" "0.21.5"
+
+esbuild@^0.25.4:
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.4.tgz#bb9a16334d4ef2c33c7301a924b8b863351a0854"
+  integrity sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.25.4"
+    "@esbuild/android-arm" "0.25.4"
+    "@esbuild/android-arm64" "0.25.4"
+    "@esbuild/android-x64" "0.25.4"
+    "@esbuild/darwin-arm64" "0.25.4"
+    "@esbuild/darwin-x64" "0.25.4"
+    "@esbuild/freebsd-arm64" "0.25.4"
+    "@esbuild/freebsd-x64" "0.25.4"
+    "@esbuild/linux-arm" "0.25.4"
+    "@esbuild/linux-arm64" "0.25.4"
+    "@esbuild/linux-ia32" "0.25.4"
+    "@esbuild/linux-loong64" "0.25.4"
+    "@esbuild/linux-mips64el" "0.25.4"
+    "@esbuild/linux-ppc64" "0.25.4"
+    "@esbuild/linux-riscv64" "0.25.4"
+    "@esbuild/linux-s390x" "0.25.4"
+    "@esbuild/linux-x64" "0.25.4"
+    "@esbuild/netbsd-arm64" "0.25.4"
+    "@esbuild/netbsd-x64" "0.25.4"
+    "@esbuild/openbsd-arm64" "0.25.4"
+    "@esbuild/openbsd-x64" "0.25.4"
+    "@esbuild/sunos-x64" "0.25.4"
+    "@esbuild/win32-arm64" "0.25.4"
+    "@esbuild/win32-ia32" "0.25.4"
+    "@esbuild/win32-x64" "0.25.4"
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -2996,7 +3150,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.4.0, tslib@^2.6.3, tslib@^2.8.0:
+tslib@^2.4.0, tslib@^2.6.3:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
Switched from swc to [esbuild](https://esbuild.github.io).


The following modules have also changed as we transition to esbuild:

| Type        | Original  | Change  |
| ----------- | --------- | ------- |
| Transformer | swc       | esbuild |
| Generator   | escodegen | astring |
